### PR TITLE
Add optional timeout parameter to the config

### DIFF
--- a/signnow_python_sdk/config.py
+++ b/signnow_python_sdk/config.py
@@ -1,4 +1,5 @@
 from base64 import b64encode
+import unirest
 
 CLIENT_ID = ''
 CLIENT_SECRET = ''
@@ -24,6 +25,8 @@ class Config(object):
                 CLIENT_SECRET = kwargs['client_secret']
             if 'base_url' in kwargs:
                 BASE_URL = kwargs['base_url']
+            if 'timeout' in kwargs:
+                unirest.timeout(kwargs['timeout'])
         else:
             self.client_id = CLIENT_ID
             self.client_secret = CLIENT_SECRET


### PR DESCRIPTION
This is more of an RFC / general suggestion. 

I have been running into quite a bit of trouble with the python SDK timing out on every request I make so I wanted to propose there be some way of changing the default timeout of the unirest requests. 

This is how I patched it on my local machine to make it work for my purposes, it's an optional parameter that doesn't change any existing behavior. 