### PR TITLE
Python v3

### DIFF
--- a/signnow_python_sdk/oauth2token.py
+++ b/signnow_python_sdk/oauth2token.py
@@ -48,4 +48,4 @@ class OAuth2(object):
             "Accept": "application/json"
         })
 
-        return request.body
+        return json.loads(request.content)

--- a/signnow_python_sdk/user.py
+++ b/signnow_python_sdk/user.py
@@ -22,7 +22,7 @@ class User(object):
             "Authorization": "Basic " + Config().get_encoded_credentials(),
             "Accept": "application/json",
             "Content-Type": "application/json"
-        }, params=dumps({
+        }, data=dumps({
             "email": email,
             "password": password,
             "first_name": first_name,

--- a/signnow_python_sdk/user.py
+++ b/signnow_python_sdk/user.py
@@ -29,7 +29,7 @@ class User(object):
             "last_name": last_name
         }))
 
-        return request.body
+        return loads(request.content)
 
     @staticmethod
     def get(access_token):
@@ -47,4 +47,4 @@ class User(object):
             "Accept": "application/json"
         })
 
-        return request.body
+        return loads(request.content)


### PR DESCRIPTION
Fixing two issues here:
1. `User.create()`, `User.get()` and `OAuth2.verify()` will now return actual response payload instead of `'Response' object has no attribute 'body'`
2. `User.create()` now passes params to the body of the request, before it was always getting the:
`{
    "errors": [
        {
            "code": 65536,
            "message": "Invalid payload"
        }
    ]
}`